### PR TITLE
Fixed FP16 rate heuristic logic and updated AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,7 @@ Three sources feed the estimator:
 - **`hardware-presets.js`** — `RAM_PRESETS` (kept here), plus `mergeCpuPresets()`/`mergeGpuPresets()` functions to load the vendor JSON files, and `findCpuPreset()`/`findRamPreset()` lookup functions.
 - **`calcPerLayerFootprint` / `estimatePerformance`** in `calculations.js` — group tensors by `/^blk\.(\d+)\./`, fold active-expert fraction into per-layer byte totals for MoE layers, then iterate `max(FLOPs/FLOPS, bytes/BW)` per layer. Bottleneck label compares aggregate compute-time vs. BW-time per device side; `cpu-dram-spill` fires when CPU layers exceed 50% of total decode time.
 
-**FP16 rate caveat for data-center cards**: the CSV reports shader-rate FP16 (often 1:64 of tensor-core rate) for H100 / B200. Preprocessor uses `max(BF16, FP16 if ≥ 1.5× FP32, FP32 × 2)` to approximate the tensor-core path, but the result is conservative for Hopper/Blackwell — users can override with `--gpu-flops`.
+**FP16 rate heuristic**: the CSV's `Theoretical Performance__FP16 (half)` column reports the theoretical peak tensor-core rate (2× FP32) for all cards. Data-center cards (A100, H100, B200) use tensor cores for FP16 — captured by the `BF16` column when populated. Turing/Volta cards (RTX 20-series, GTX 16-series, TITAN RTX/V/Xp, Quadro RTX/T/GP) use FP16 cores for 2× FP32. But consumer GeForce RTX 30/40/50-series and professional Ampere/Ada cards do NOT use tensor cores for FP16, so FP16 = FP32. The preprocessor logic: `BF16 > 0 → BF16; else FP16 ≥ 1.5× FP32 && Turing/Volta match → FP16; else FP32`. Users can override with `--gpu-flops`.
 
 ### Mobile / server group split
 

--- a/scripts/build-gpu-list.js
+++ b/scripts/build-gpu-list.js
@@ -155,14 +155,16 @@ for (let r = 1; r < rows.length; r++) {
   const hasTensor = !!row[COL['Render Config__Tensor Cores']];
 
   // Effective FP16 rate for LLM inference (tensor-core path when available).
-  // On consumer NVIDIA the CSV's FP16 column often reports the 1:64 "shader"
-  // rate, which is meaningless for llama.cpp. Prefer BF16 (populated for
-  // data-center cards), else FP16 when plausibly tensor-core (≥ 2× FP32),
-  // else fall back to FP32 × 2 as an approximation of tensor-core FP16.
+  // Data-center cards (A100, H100, B200, etc.) use tensor cores for FP16,
+  // so FP16 is 2x-16x FP32 — captured by the BF16 column when populated.
+  // Turing/Volta cards (RTX 20-series, GTX 16-series, TITAN RTX/V/Xp,
+  // Quadro RTX/T/GP) use FP16 cores for 2x FP32. But consumer GeForce
+  // RTX 30/40/50-series and professional Ampere/Ada cards do NOT use
+  // tensor cores for FP16, so FP16 = FP32.
   let fp16;
   if (bf16 && bf16 > 0) fp16 = bf16;
-  else if (fp16Raw && fp32 && fp16Raw >= fp32 * 1.5) fp16 = fp16Raw;
-  else if (fp32) fp16 = fp32 * 2;
+  else if (fp16Raw && fp32 && fp16Raw >= fp32 * 1.5 && /RTX [2]0|GTX 1[6]|TITAN [RVXx]|Quadro [RTG]/i.test(name)) fp16 = fp16Raw;
+  else if (fp32) fp16 = fp32;
   else fp16 = fp16Raw;
 
   if (!memBwGBps || !fp16) continue;  // unusable for throughput estimate


### PR DESCRIPTION
1. scripts/build-gpu-list.js — Fixed the FP16 rate heuristic logic (lines ~163-168). Changed from accepting the CSV's FP16 column whenever it's ≥ 1.5× FP32, to only accepting it for Turing/Volta cards (RTX 20-series, GTX 16-series, TITAN RTX/V/Xp, Quadro RTX/T/GP). All other cards now use FP32 as their FP16 rate.

2. AGENTS.md — Updated the FP16 rate documentation to accurately describe the new heuristic (architecture-based instead of year-based).

Addresses #4 